### PR TITLE
Fix for missing WebAssemblyMessageHandler

### DIFF
--- a/samples/Client/SerilogBlazorDemo.Client.csproj
+++ b/samples/Client/SerilogBlazorDemo.Client.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.1.0-preview2.19528.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.1.0-preview2.19528.8" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.HttpClient" Version="3.1.0-preview2.19528.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.DevServer" Version="3.1.0-preview2.19528.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.1.0-preview3.19555.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.1.0-preview3.19555.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.HttpClient" Version="3.1.0-preview3.19555.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.DevServer" Version="3.1.0-preview3.19555.2" PrivateAssets="all" />
     <PackageReference Include="Serilog.Sinks.BrowserConsole" Version="1.0.0-dev-00012" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/Server/SerilogBlazorDemo.Server.csproj
+++ b/samples/Server/SerilogBlazorDemo.Server.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="3.1.0-preview2.19528.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="3.1.0-preview3.19555.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.1.0" />
   </ItemGroup>
 

--- a/src/Serilog.Sinks.BrowserHttp/Serilog.Sinks.BrowserHttp.csproj
+++ b/src/Serilog.Sinks.BrowserHttp/Serilog.Sinks.BrowserHttp.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.2.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview9.19465.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.1.0-preview3.19555.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Serilog.Sinks.BrowserHttp/Sinks/BrowserHttp/BrowserHttpSink.cs
+++ b/src/Serilog.Sinks.BrowserHttp/Sinks/BrowserHttp/BrowserHttpSink.cs
@@ -60,7 +60,7 @@ namespace Serilog.Sinks.BrowserHttp
             _eventBodyLimitBytes = eventBodyLimitBytes;
             _controlledSwitch = new ControlledLevelSwitch(levelControlSwitch);
             _httpClient = messageHandler == null ?
-                new HttpClient(new WebAssemblyHttpMessageHandler()) { BaseAddress = GetBaseAddress() } :
+                new HttpClient() { BaseAddress = GetBaseAddress() } :
                 new HttpClient(messageHandler) { BaseAddress = GetBaseAddress() };
         }
 


### PR DESCRIPTION
Latest preview3 seems to remove `WebAssemblyHttpMessageHandler`.  I didn't see any announcements about it, but it broke the package.  I simply removed its use as a parameter and it fixed the library.  I also updated to preview3 across the repo.