### PR TITLE
Remove Code That Retrieves Base Address

### DIFF
--- a/src/Serilog.Sinks.BrowserHttp/Serilog.Sinks.BrowserHttp.csproj
+++ b/src/Serilog.Sinks.BrowserHttp/Serilog.Sinks.BrowserHttp.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.2.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.0-preview4.20210.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Serilog.Sinks.BrowserHttp/Sinks/BrowserHttp/BrowserHttpSink.cs
+++ b/src/Serilog.Sinks.BrowserHttp/Sinks/BrowserHttp/BrowserHttpSink.cs
@@ -59,15 +59,8 @@ namespace Serilog.Sinks.BrowserHttp
 			_eventBodyLimitBytes = eventBodyLimitBytes;
 			_controlledSwitch = new ControlledLevelSwitch(levelControlSwitch);
 			_httpClient = messageHandler == null ?
-				new HttpClient() { BaseAddress = GetBaseAddress() } :
-				new HttpClient(messageHandler) { BaseAddress = GetBaseAddress() };
-		}
-
-		static Uri GetBaseAddress()
-		{
-			var builder = WebAssemblyHostBuilder.CreateDefault();
-
-			return new Uri(builder.HostEnvironment.BaseAddress);
+				new HttpClient() { } :
+				new HttpClient(messageHandler) { };
 		}
 
 		protected override void Dispose(bool disposing)

--- a/src/Serilog.Sinks.BrowserHttp/Sinks/BrowserHttp/BrowserHttpSink.cs
+++ b/src/Serilog.Sinks.BrowserHttp/Sinks/BrowserHttp/BrowserHttpSink.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
@@ -29,7 +28,7 @@ using System.Threading.Tasks;
 
 namespace Serilog.Sinks.BrowserHttp
 {
-	class BrowserHttpSink : PeriodicBatchingSink
+    class BrowserHttpSink : PeriodicBatchingSink
 	{
 		public const int DefaultBatchPostingLimit = 1000;
 		public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(2);


### PR DESCRIPTION
This solves my issue for #10, though I did mention that I wasn't clear why it was there to begin with.

Once I changed this in my local forked copy, it worked as expected.

Related but not addressed in this PR, it wasn't immediately clear from the README that my "endpoint" URL should include `/ingest`.   Hooray open source and your continued awesomeness for putting this out in the community! 