### PR TITLE
Ability to pass custom headers to http client

### DIFF
--- a/src/Serilog.Sinks.BrowserHttp/LoggerConfigurationBrowserHttpExtensions.cs
+++ b/src/Serilog.Sinks.BrowserHttp/LoggerConfigurationBrowserHttpExtensions.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using Serilog.Configuration;
 using Serilog.Core;
@@ -58,7 +59,8 @@ namespace Serilog
             long? eventBodyLimitBytes = 256 * 1024,
             LoggingLevelSwitch controlLevelSwitch = null,
             int queueSizeLimit = BrowserHttpSink.DefaultQueueSizeLimit,
-            HttpMessageHandler messageHandler = null)
+            HttpMessageHandler messageHandler = null,
+            IDictionary<string, string> httpHeaders = null)
         {
             if (loggerSinkConfiguration == null) throw new ArgumentNullException(nameof(loggerSinkConfiguration));
             if (endpointUrl == null) throw new ArgumentNullException(nameof(endpointUrl));
@@ -74,7 +76,8 @@ namespace Serilog
                 eventBodyLimitBytes,
                 controlLevelSwitch,
                 queueSizeLimit,
-                messageHandler);
+                messageHandler,
+                httpHeaders);
 
             return loggerSinkConfiguration.Sink(sink, restrictedToMinimumLevel);
         }

--- a/src/Serilog.Sinks.BrowserHttp/LoggerConfigurationBrowserHttpExtensions.cs
+++ b/src/Serilog.Sinks.BrowserHttp/LoggerConfigurationBrowserHttpExtensions.cs
@@ -60,7 +60,7 @@ namespace Serilog
             LoggingLevelSwitch controlLevelSwitch = null,
             int queueSizeLimit = BrowserHttpSink.DefaultQueueSizeLimit,
             HttpMessageHandler messageHandler = null,
-            IDictionary<string, string> httpHeaders = null)
+            IDictionary<string, string> defaultRequestHeaders = null)
         {
             if (loggerSinkConfiguration == null) throw new ArgumentNullException(nameof(loggerSinkConfiguration));
             if (endpointUrl == null) throw new ArgumentNullException(nameof(endpointUrl));
@@ -77,7 +77,7 @@ namespace Serilog
                 controlLevelSwitch,
                 queueSizeLimit,
                 messageHandler,
-                httpHeaders);
+                defaultRequestHeaders);
 
             return loggerSinkConfiguration.Sink(sink, restrictedToMinimumLevel);
         }

--- a/src/Serilog.Sinks.BrowserHttp/Sinks/BrowserHttp/BrowserHttpSink.cs
+++ b/src/Serilog.Sinks.BrowserHttp/Sinks/BrowserHttp/BrowserHttpSink.cs
@@ -51,7 +51,8 @@ namespace Serilog.Sinks.BrowserHttp
 			long? eventBodyLimitBytes,
 			LoggingLevelSwitch levelControlSwitch,
 			int queueSizeLimit,
-			HttpMessageHandler messageHandler)
+			HttpMessageHandler messageHandler,
+			IDictionary<string, string> httpHeaders)
 			: base(batchPostingLimit, period, queueSizeLimit)
 		{
 			_endpointUrl = endpointUrl ?? throw new ArgumentNullException(nameof(endpointUrl));
@@ -60,6 +61,15 @@ namespace Serilog.Sinks.BrowserHttp
 			_httpClient = messageHandler == null ?
 				new HttpClient() { } :
 				new HttpClient(messageHandler) { };
+
+			if(httpHeaders != null)
+            {
+				var keys = httpHeaders.Keys;
+				foreach(var key in keys)
+                {
+					_httpClient.DefaultRequestHeaders.Add(key, httpHeaders[key]);
+                }
+            }
 		}
 
 		protected override void Dispose(bool disposing)

--- a/src/Serilog.Sinks.BrowserHttp/Sinks/BrowserHttp/BrowserHttpSink.cs
+++ b/src/Serilog.Sinks.BrowserHttp/Sinks/BrowserHttp/BrowserHttpSink.cs
@@ -52,7 +52,7 @@ namespace Serilog.Sinks.BrowserHttp
 			LoggingLevelSwitch levelControlSwitch,
 			int queueSizeLimit,
 			HttpMessageHandler messageHandler,
-			IDictionary<string, string> httpHeaders)
+			IDictionary<string, string> defaultRequestHeaders)
 			: base(batchPostingLimit, period, queueSizeLimit)
 		{
 			_endpointUrl = endpointUrl ?? throw new ArgumentNullException(nameof(endpointUrl));
@@ -62,14 +62,13 @@ namespace Serilog.Sinks.BrowserHttp
 				new HttpClient() { } :
 				new HttpClient(messageHandler) { };
 
-			if(httpHeaders != null)
-            {
-				var keys = httpHeaders.Keys;
-				foreach(var key in keys)
-                {
-					_httpClient.DefaultRequestHeaders.Add(key, httpHeaders[key]);
-                }
-            }
+			if (defaultRequestHeaders != null)
+			{
+				foreach (var header in defaultRequestHeaders)
+				{
+					_httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
+				}
+			}
 		}
 
 		protected override void Dispose(bool disposing)


### PR DESCRIPTION
This solves issue #7, we can pass in an authorization header into the dictionary, or any other headers you may need to.